### PR TITLE
fix: deployment error

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,9 +1,6 @@
 import NextAuth from 'next-auth';
-import { NextApiRequest, NextApiResponse } from 'next';
 import { authOptions } from '@/utils';
 
-const handler = async function auth(req: NextApiRequest, res: NextApiResponse) {
-  return await NextAuth(req, res, authOptions);
-};
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };


### PR DESCRIPTION
update `NextAuth` call to fix error `NextAuth Type "NextApiRequest" is not a valid type for the function's first argument. Expected "Request | NextRequest", got "NextApiRequest".`